### PR TITLE
Implement `respond_to?` in module Monad

### DIFF
--- a/lib/monads/monad.rb
+++ b/lib/monads/monad.rb
@@ -12,6 +12,12 @@ module Monads
       end
     end
 
+    def respond_to_missing?(method_name, include_private=false)
+      super || within do |value|
+        value.respond_to?(method_name, include_private)
+      end
+    end
+
     private
 
     def ensure_monadic_result(&block)


### PR DESCRIPTION
Prompted by your statement

> If this was production code, we should remember to implement [`#respond_to?`](http://rubydoc.info/stdlib/core/Object#respond_to%3F-instance_method) as well.

at [codon.com – Refactoring Ruby with Monads](http://codon.com/refactoring-ruby-with-monads).

I implemented `#respond_to?` by implementing `#respond_to_missing?`, as recommended by [thoughtbot – Always Define `respond_to_missing?` When Overriding `method_missing`](http://robots.thoughtbot.com/always-define-respond-to-missing-when-overriding), so that `#method` also works. This requires Ruby 1.9 and later.