### PR TITLE
Get rid of unnecessary methods brought by using Struct as superclass

### DIFF
--- a/lib/monads/optional.rb
+++ b/lib/monads/optional.rb
@@ -1,8 +1,13 @@
 require 'monads/monad'
 
 module Monads
-  Optional = Struct.new(:value) do
+  class Optional
     include Monad
+    attr_accessor :value
+
+    def initialize(value)
+      @value = value
+    end
 
     def and_then(&block)
       block = ensure_monadic_result(&block)


### PR DESCRIPTION
Figured that out when I wanted to use `first` as a valid method name on something I had wrapped in `Monads::Optional`.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/tomstuart/monads/7)
<!-- Reviewable:end -->
