### PR TITLE
Feature #8 delicate array wrapping Many.from_value

### DIFF
--- a/lib/monads/many.rb
+++ b/lib/monads/many.rb
@@ -11,7 +11,7 @@ module Monads
     end
 
     def self.from_value(value)
-      Many.new([value])
+      Many.new(Array(value))
     end
   end
 end

--- a/spec/monads/many_spec.rb
+++ b/spec/monads/many_spec.rb
@@ -48,6 +48,14 @@ module Monads
       it 'wraps a value in a Many' do
         expect(Many.from_value(value).values).to eq [value]
       end
+
+      context 'when value is Enumerable' do
+        let(:outer_many) { [double(inner_many: inner_many)] }
+        let(:inner_many) { [double(data: data)] }
+        let(:data) { [1, 2, 3, 4] }
+
+        it { expect(Many.from_value(outer_many).inner_many.data.values).to eq data }
+      end
     end
 
     describe '#within' do


### PR DESCRIPTION
In my thoughts this feature also adds problem when value is Hash. Since after ``` Many.from_value ``` it would not be same object as expected, for example.
But on the other hand following code would work well (borrowed from #8):
```ruby
Blaher = Struct.new(:blahs)
Bloher = Struct.new(:blohs)
blahers = [Blaher.new([Bloher.new([1, 2, 3, 4])])]
Monads::Many.new(blahers).blahs.blohs.values
# => [1,2,3,4]
```
This PR is opened for discussion.